### PR TITLE
chore(babel): use new es2015 preset options

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,12 +49,12 @@
     "sql.js": "^0.3.2"
   },
   "devDependencies": {
+    "babel-core": "^6.13.2",
     "babel-eslint": "^6.1.0",
     "babel-plugin-syntax-flow": "^6.13.0",
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-plugin-transform-runtime": "^6.9.0",
-    "babel-preset-es2015": "^6.9.0",
-    "babel-preset-es2015-rollup": "^1.1.1",
+    "babel-preset-es2015": "^6.13.2",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.9.0",
     "babel-runtime": "^6.11.6",
@@ -77,7 +77,7 @@
     "jsdoc-strip-async-await": "^0.1.0",
     "mocha": "^2.5.3",
     "rollup": "^0.34.0",
-    "rollup-plugin-babel": "^2.5.1",
+    "rollup-plugin-babel": "^2.6.1",
     "rollup-watch": "^2.5.0"
   },
   "config": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,10 @@ export default {
   plugins: [
     babel({
       babelrc: false,
-      presets: ['es2015-rollup', 'stage-0'],
+      presets: [
+        ['es2015', { modules: false }],
+        'stage-0'
+      ],
       plugins: [
         'syntax-flow',
         'transform-flow-strip-types',


### PR DESCRIPTION
Remove dependency on babel-preset-es2015-rollup. Move to the standard es2015 preset which has a new option to disable module transformations.

Add babel-core to dev deps to fix what seems like rollup using an old version.

This should hopefully fix Travis.