### PR TITLE
fix(tests): fix error in deletion tests

### DIFF
--- a/tests/deletions.js
+++ b/tests/deletions.js
@@ -42,8 +42,8 @@ test.serial('removes a row from the specified table', async t => {
 test.serial('removes all rows from the specified table', async t => {
   await db.del('people')
 
-  morePeople.forEach(async person => {
-    const res = await db.first('people', { name: person })
+  morePeople.forEach(async ({ name }) => {
+    const res = await db.first('people', { name })
     t.falsy(res)
   })
 })


### PR DESCRIPTION
The `where` argument should be the `name` property from the object pulled from `morePeople`. Instead the object itself was being mapped to the name property of the where arg.