### PR TITLE
Make `create()` return the object

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -366,7 +366,7 @@ insert will be ignored when violating this constraint.
 
 > **Returns**
 
-`Promise<Number>`: the number of objects created
+`Promise<Object>`: the created object
 
 > **Usage**
 
@@ -375,6 +375,11 @@ players.create({
   id: 197397332,
   username: 'xX420_sniperXx',
   friends: ['xX420_kniferXx']
+}).then(object => {
+  console.log(object)
+  // { id: 197397332,
+  //   username: 'xX420_sniperXx',
+  //   friends: ['xX420_kniferXx'] }
 })
 ```
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -104,16 +104,7 @@ export function runQuery (instance, query, needResponse) {
 }
 
 export function findLastObject (model, object) {
-  let key = ''
-  let hasIncrements = false
-  util.each(model.schema, (props, name) => {
-    if (props === 'increments' || props.type === 'increments') {
-      key = name
-      hasIncrements = true
-    } else if (props.primary) {
-      key = name
-    }
-  })
+  let { key, hasIncrements } = findKey(model.schema)
 
   if (!key && !hasIncrements) return
 
@@ -123,6 +114,24 @@ export function findLastObject (model, object) {
 
   return runQuery(model.ctx, query, true)
     .then(res => hasIncrements ? model.findOne({ [key]: res.seq }) : res)
+}
+
+function findKey (schema) {
+  let key = ''
+  let hasIncrements = false
+  for (let name in schema) {
+    if (!schema.hasOwnProperty(name)) continue
+    let props = schema[name]
+    if (props === 'increments' || props.type === 'increments') {
+      key = name
+      hasIncrements = true
+      break
+    } else if (props.primary || props.unique) {
+      key = name
+    }
+  }
+
+  return { key, hasIncrements }
 }
 
 function getQueryAction (str) {

--- a/src/model.js
+++ b/src/model.js
@@ -21,6 +21,8 @@ export default class Model {
     )
 
     return helpers.runQuery(this.ctx, query)
+      .then(() => helpers.findLastObject(this, object))
+      .then(res => res || this.findOne(object))
   }
 
   find (column, criteria, options = {}) {
@@ -91,7 +93,6 @@ export default class Model {
       .then(existing => {
         if (existing) return existing
         return this.create({ ...criteria, ...creation })
-          .then(() => this.findOne(criteria))
       })
   }
 

--- a/tests/find-or-create.js
+++ b/tests/find-or-create.js
@@ -1,0 +1,38 @@
+import Trilogy from '../dist/trilogy'
+
+import test from 'ava'
+import { remove } from 'fs-jetpack'
+import { join, basename } from 'path'
+
+const filePath = join(__dirname, `${basename(__filename, '.js')}.db`)
+const db = new Trilogy(filePath)
+
+const makeInput = date => ({ name: 'Overwatch', last_played: date, genre: 'FPS' })
+
+test.before(async () => {
+  await db.model('games', {
+    name: { type: String, primary: true },
+    last_played: Date,
+    genre: String
+  })
+})
+
+test.after.always('remove test database file', () => {
+  return db.close().then(() => remove(filePath))
+})
+
+test('creates missing objects or returns an existing one', async t => {
+  t.is(await db.count('games', { genre: 'FPS' }), 0)
+
+  let first = makeInput(new Date('Jan 31, 2017'))
+  let fresh = await db.findOrCreate('games', first)
+  t.is(await db.count('games', { genre: 'FPS' }), 1)
+
+  let duplicate = makeInput(new Date('Feb 2, 2017'))
+  let existing = await db.findOrCreate('games', duplicate)
+  t.deepEqual(fresh, existing)
+  t.is(await db.count('games', { genre: 'FPS' }), 1)
+
+  t.is(fresh.last_played, existing.last_played)
+})
+

--- a/tests/model.js
+++ b/tests/model.js
@@ -28,7 +28,7 @@ test('defines a model with a uniquely constrained property', async t => {
 
   let object = { name: 'coke', flavor: 'awesome' }
   await db.create('sodas', object)
+  await db.create('sodas', object)
 
-  let duplicate = await db.create('sodas', object)
-  t.is(duplicate, 0)
+  t.is(await db.count('sodas', { name: 'coke' }), 1)
 })


### PR DESCRIPTION
Following discussion in #21, and possibly superseding #22.

Updates the return value of `create()` to be the created value rather than the number of updated rows. This is a breaking change, but it makes more sense given that the number modified would always have been 0 or 1 so it might as well give you the object if 1, or nothing if 0.

If the model schema has an auto-incrementing primary key, the table is queried to find the last increment and that is used to return the object. If not, a standard primary key or unique constraint will be used. If neither of these exists in the schema the creation object itself will be used as criteria as a best-effort to return the created object.