### PR TITLE
fix(findOne): error when no result and column provided

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -1,7 +1,7 @@
 import * as types from './types'
 import * as helpers from './helpers'
 import * as enforcers from './enforcers'
-import { isArray, isString, isObject } from './util'
+import { isArray, isString, isObject, isNil } from './util'
 
 export default class Model {
   constructor (ctx, name, schema, options) {
@@ -76,6 +76,7 @@ export default class Model {
 
     return helpers.runQuery(this.ctx, query, true).then(response => {
       let result = isArray(response) ? response[0] : response
+      if (isNil(result)) return result
 
       if (!column) {
         return types.fromDefinition(this, result)

--- a/src/util.js
+++ b/src/util.js
@@ -40,6 +40,7 @@ export let isFunction = value => isType(value, 'function')
 export let isString = value => isType(value, 'string')
 export let isNumber = value => isType(value, 'number')
 export let isBoolean = value => isType(value, 'boolean')
+export let isNil = value => value == null
 
 export function invariant (condition, message) {
   if (!condition) {


### PR DESCRIPTION
Return early if result is null or undefined to prevent errors from trying to read properties of it if provided a column.