### PR TITLE
Add Node 8 to Travis test versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,8 @@
-dist: trusty
-
 language: node_js
 node_js:
-  - '4'
-  - '6'
-  - '7'
   - '8'
-
-cache:
-  directories:
-    - node_modules
+  - '6'
+  - '4'
 
 before_install:
   - if [[ `npm -v` == 2* ]]; then npm i -g npm@latest; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,5 @@ node_js:
 before_install:
   - if [[ `npm -v` == 2* ]]; then npm i -g npm@latest; fi
 
-install:
-  - npm prune
-  - npm install
-
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,18 @@
-sudo: false
+dist: trusty
 
 language: node_js
 node_js:
   - '4'
   - '6'
   - '7'
-
-branches:
-  only:
-    - master
+  - '8'
 
 cache:
   directories:
     - node_modules
 
 before_install:
-  - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
+  - if [[ `npm -v` == 2* ]]; then npm i -g npm@latest; fi
 
 install:
   - npm prune

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: node_js
 node_js:
   - '8'


### PR DESCRIPTION
Travis image evidently doesn't currently have a C++ compiler compatible with Node 8's toolchain. Attempt to fix by installing it manually.