### PR TITLE
fix: ensure timestamps/schema options are handled properly

### DIFF
--- a/src/schema-helpers.ts
+++ b/src/schema-helpers.ts
@@ -29,13 +29,17 @@ export function toKnexSchema <D extends types.ReturnDict> (
     for (const [name, descriptor] of Object.entries(model.schema)) {
       // these timestamp fields are handled as part of the model options
       // processing below, ignore them here so we don't duplicate the fields
-      if (options.timestamps && (name === 'created_at' || name === 'updated_at')) return
+      if (options.timestamps && (name === 'created_at' || name === 'updated_at')) {
+        continue
+      }
 
       // each column's value is either its type or a descriptor
       const type = getDataType(descriptor)
       const partial = table[toKnexMethod(type)](name)
 
-      if (isFunction(descriptor) || !isObject(descriptor)) return
+      if (isFunction(descriptor) || !isObject(descriptor)) {
+        continue
+      }
 
       const props = types.ColumnDescriptor.check(descriptor)
 

--- a/tests/issues/110.ts
+++ b/tests/issues/110.ts
@@ -1,0 +1,25 @@
+import test from 'ava'
+import { connect } from '../../src'
+
+const db = connect(':memory:')
+
+test.before(async () => {
+  const tests = await db.model('tests', {
+    id: 'increments',
+    item: String
+  }, {
+    timestamps: true
+  })
+
+  await tests.create({
+    item: 'test'
+  })
+})
+
+test.after.always(() => db.close())
+
+test('timestamp fields are available on created objects', async t => {
+  const found = await db.findOne('tests', { item: 'test' })
+  t.true(found.created_at instanceof Date)
+  t.true(found.updated_at instanceof Date)
+})


### PR DESCRIPTION
Closes #110

Don't return early from the `createTable` call - instead continue from the schema loop so that options are properly processed below.

<!--

Please read the [Contributor Guide](https://github.com/citycide/trilogy/blob/master/.github/contributing.md).

- include a description of the changes
- try to include motivating cases
- also try to provide before & after comparisons / expectations
- if this closes an issue, add `Closes #{issue number}` as the opening line
  - this also works for pull requests if you're replacing a previous one

Thanks for contributing!

-->
